### PR TITLE
Load library order

### DIFF
--- a/lib/ffi-compiler/loader.rb
+++ b/lib/ffi-compiler/loader.rb
@@ -9,7 +9,11 @@ module FFI
         library = Platform.system.map_library_name(name)
         root = false
         Pathname.new(start_path || caller_path(caller[0])).ascend do |path|
-          Dir.glob("#{path}/**/{#{FFI::Platform::ARCH}-#{FFI::Platform::OS}/#{library},#{library}}") do |f|
+          Dir.glob("#{path}/**/#{FFI::Platform::ARCH}-#{FFI::Platform::OS}/#{library}") do |f|
+            return f
+          end
+
+          Dir.glob("#{path}/**/#{library}") do |f|
             return f
           end
 


### PR DESCRIPTION
Fixes load of a wrong library file on Windows. Previously on x86_64 it took the first file, which is wrong:

```
libmspack-0.1.0/ext/i386-windows/libmspack.dll
libmspack-0.1.0/ext/x86_64-windows/libmspack.dll
```

See https://github.com/davispuh/ruby-libmspack/issues/1